### PR TITLE
Updated the version info in the config file. Took out array dependency.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Haikunator.Mixfile do
   def project do
     [app: :haikunator,
      description: "Generate Heroku-like memorable random names to use in your apps or anywhere else.",
-     version: "1.0.0",
+     version: "1.0.1",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -34,7 +34,6 @@ defmodule Haikunator.Mixfile do
   defp deps do
     [{:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.7", only: :dev},
-     {:inch_ex, only: :docs},
-     {:array, "~> 1.0.1"}]
+     {:inch_ex, only: :docs}]
   end
 end


### PR DESCRIPTION
The compile and Hex package still had the Array calls in it. When I pulled the latest from Hex, the Array code was still in it. I figured that the version number might be causing it.
